### PR TITLE
Refactor error constructor

### DIFF
--- a/structured_error.go
+++ b/structured_error.go
@@ -80,11 +80,7 @@ func (e *StructuredError) Error() string {
 // New creates a new Error with the given code and message.
 // It returns an Error interface that can be used with all the methods defined in the interface.
 func New(code string, message string) Error {
-	return &StructuredError{
-		reason:   NewDefaultReason(code, message),
-		GRPCCode: codes.Unknown,
-		HTTPCode: 500,
-	}
+	return NewWithHTTPAndGRPC(code, message, 500, codes.Unknown)
 }
 
 // WithReason adds a user-facing reason to the error.


### PR DESCRIPTION
## Summary
- refactor `New` constructor to leverage `NewWithHTTPAndGRPC` and reduce duplication

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: unsupported config version)*

------
https://chatgpt.com/codex/tasks/task_e_688f5f4012b08323ac10ab35e54fb3ee